### PR TITLE
Replace CLAPOutBuffer.h include in SFZ library

### DIFF
--- a/SFZPlayer/SFZVoice.cpp
+++ b/SFZPlayer/SFZVoice.cpp
@@ -4,7 +4,7 @@
 #include "SFZSample.h"
 #include "SFZSynth.h"
 #include "SampleBuffer.h"
-#include "CLAPOutBuffer.h"
+#include "OutBuffer.h"
 #include "Decibels.h"
 #include "SFZFloat.h"
 #include "MIDINoteFrequency.h"


### PR DESCRIPTION
SFZVoice.cpp included CLAPOutBuffer.h, which is a dependency on the CLAP library. It only really needs OutBuffer.h, which is in the SFZ library. This commit removes the cross-library dependency.

Note that I don't know if this is a good idea given everything else this application is doing. I'm trying to get the SFZ stuff integrated into my Teensy app so eliminating dependencies out of SFZPlayer is helpful. If this disrupts the overall program, obviously you should reject this change!