### PR TITLE
Fix compile errors by adding cstdint

### DIFF
--- a/SFZPlayer/SFZSynth.cpp
+++ b/SFZPlayer/SFZSynth.cpp
@@ -5,6 +5,7 @@
 #include "MIDINoteFrequency.h"
 #include <sstream>
 #include <stdlib.h>
+#include <cstdint>
 
 
 SFZSynth::SFZSynth(int num_voices)

--- a/SettingsParser.cpp
+++ b/SettingsParser.cpp
@@ -1,5 +1,5 @@
 #include "SettingsParser.h"
-
+#include <cstdint>
 
 void SettingsParser::parse(const SettingHandler& handler)
 {

--- a/SettingsParser.h
+++ b/SettingsParser.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <sstream>
+#include <cstdint>
 
 
 class SettingsParser {


### PR DESCRIPTION
Adds `#include <cstdint>` to fix compile errors while compiling via Nix